### PR TITLE
make test-progress more visible; set up envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,16 @@ language: python
 python:
   - '3.5'
   - '3.6'
+  - '3.7'
 matrix:
   include:
-  - python:
-    - '3.7'
     dist: xenial
     sudo: true
   fast_finish: true
 services:
 - postgresql
-env:
-- TOX_ENV=py36-django-22
-- TOX_ENV=py35-django-22
-install: pip install -r requirements-test.txt
-script: tox -e $TOX_ENV
+install: pip install tox-travis
+script: tox
 after_success:
 - codecov -e TOX_ENV
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
-matrix:
-  include:
-    dist: xenial
-    sudo: true
-  fast_finish: true
 services:
 - postgresql
 install: pip install tox-travis

--- a/src/runtests.py
+++ b/src/runtests.py
@@ -10,6 +10,6 @@ if __name__ == "__main__":
     os.environ['DJANGO_SETTINGS_MODULE'] = 'auditlog_tests.test_settings'
     django.setup()
     TestRunner = get_runner(settings)
-    test_runner = TestRunner()
+    test_runner = TestRunner(verbosity=2)
     failures = test_runner.run_tests(["auditlog_tests"])
     sys.exit(bool(failures))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py35,py36}-django-22
+    {py35,py36,py37}-django-22
 
 [testenv]
 setenv =
@@ -10,5 +10,6 @@ deps =
     django-22: Django>=2.2,<2.3
     -r{toxinidir}/requirements-test.txt
 basepython =
-    py36: python3.6
     py35: python3.5
+    py36: python3.6
+    py37: python3.7


### PR DESCRIPTION
This runs now on the specified python environments, also outputs the ran tests.

Open issues I'd do in a different PR: bring travis.yml up to date, the UI prints some messages about outdated keys.